### PR TITLE
drop unneeded wow node stuff

### DIFF
--- a/Misc/Disable-ActiveX.ps1
+++ b/Misc/Disable-ActiveX.ps1
@@ -5,10 +5,6 @@ New-Item "HKLM:\SOFTWARE\Policies\Microsoft\Windows\CurrentVersion\Internet Sett
 New-Item "HKLM:\SOFTWARE\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\1" -Force
 New-Item "HKLM:\SOFTWARE\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\2" -Force
 New-Item "HKLM:\SOFTWARE\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\3" -Force
-New-Item "HKLM:\SOFTWARE\Policies\WOW6432Node\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\0" -Force
-New-Item "HKLM:\SOFTWARE\Policies\WOW6432Node\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\1" -Force
-New-Item "HKLM:\SOFTWARE\Policies\WOW6432Node\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\2" -Force
-New-Item "HKLM:\SOFTWARE\Policies\WOW6432Node\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\3" -Force
 New-ItemProperty -LiteralPath 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\0' -Name '1001' -Value 3 -PropertyType DWord -Force 
 New-ItemProperty -LiteralPath 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\0' -Name '1004' -Value 3 -PropertyType DWord -Force 
 New-ItemProperty -LiteralPath 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\1' -Name '1001' -Value 3 -PropertyType DWord -Force 
@@ -17,11 +13,3 @@ New-ItemProperty -LiteralPath 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\Current
 New-ItemProperty -LiteralPath 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\2' -Name '1004' -Value 3 -PropertyType DWord -Force 
 New-ItemProperty -LiteralPath 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\3' -Name '1001' -Value 3 -PropertyType DWord -Force 
 New-ItemProperty -LiteralPath 'HKLM:\SOFTWARE\Policies\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\3' -Name '1004' -Value 3 -PropertyType DWord -Force 
-New-ItemProperty -LiteralPath 'HKLM:\SOFTWARE\Policies\WOW6432Node\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\0' -Name '1001' -Value 3 -PropertyType DWord -Force 
-New-ItemProperty -LiteralPath 'HKLM:\SOFTWARE\Policies\WOW6432Node\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\0' -Name '1004' -Value 3 -PropertyType DWord -Force 
-New-ItemProperty -LiteralPath 'HKLM:\SOFTWARE\Policies\WOW6432Node\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\1' -Name '1001' -Value 3 -PropertyType DWord -Force 
-New-ItemProperty -LiteralPath 'HKLM:\SOFTWARE\Policies\WOW6432Node\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\1' -Name '1004' -Value 3 -PropertyType DWord -Force 
-New-ItemProperty -LiteralPath 'HKLM:\SOFTWARE\Policies\WOW6432Node\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\2' -Name '1001' -Value 3 -PropertyType DWord -Force 
-New-ItemProperty -LiteralPath 'HKLM:\SOFTWARE\Policies\WOW6432Node\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\2' -Name '1004' -Value 3 -PropertyType DWord -Force 
-New-ItemProperty -LiteralPath 'HKLM:\SOFTWARE\Policies\WOW6432Node\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\3' -Name '1001' -Value 3 -PropertyType DWord -Force 
-New-ItemProperty -LiteralPath 'HKLM:\SOFTWARE\Policies\WOW6432Node\Microsoft\Windows\CurrentVersion\Internet Settings\Zones\3' -Name '1004' -Value 3 -PropertyType DWord -Force 


### PR DESCRIPTION
The regular Policy key is all you need. (Wow6432Node is a "shared" regkey that just writes to the default anyway).

See https://docs.microsoft.com/en-us/windows/win32/winprog64/shared-registry-keys#:~:text=HKEY_LOCAL_MACHINE%5CSOFTWARE%5CPolicies