### PR TITLE
Update CERTPL2Hosts to use the new version of exports

### DIFF
--- a/CERTPL2Hosts/README.md
+++ b/CERTPL2Hosts/README.md
@@ -22,8 +22,8 @@ Prosty skrypt `Update-CERTHosts.ps1` napisany w PowerShell pozwala na zautomatyz
 1. Usuń adresy dodane do pliku hosts:
     1. Uruchom cmd.exe lub PowerShell z uprawnieniami administratora,
     1. W cmd.exe lub PowerShell uruchom `notepad C:\Windows\System32\drivers\etc\hosts`,
-    1. Znajdź linię `### Start of https://hole.cert.pl/domains/domains_hosts.txt content ###` (zwykle około dwudziestej linii w pliku),
-    1. Znajdź linię `### End of https://hole.cert.pl/domains/domains_hosts.txt content ###` (zwykle na końcu pliku),
+    1. Znajdź linię `### Start of https://hole.cert.pl/domains/v2/domains_hosts.txt content ###` (zwykle około dwudziestej linii w pliku),
+    1. Znajdź linię `### End of https://hole.cert.pl/domains/v2/domains_hosts.txt content ###` (zwykle na końcu pliku),
     1. Usuń te linie i całą zawartość pomiędzy nimi,
     1. Zapisz zmodyfikowany plik hosts,
 1. Możesz również usunąć plik `Update-CERTHosts.ps1` z `C:\Program Files`.

--- a/CERTPL2Hosts/Update-CERTHosts.ps1
+++ b/CERTPL2Hosts/Update-CERTHosts.ps1
@@ -1,5 +1,5 @@
 ﻿
-$HoleCertURL = "https://hole.cert.pl/domains/domains_hosts.txt" # skąd pobieramy dane
+$HoleCertURL = "https://hole.cert.pl/domains/v2/domains_hosts.txt" # skąd pobieramy dane
 $HostsFile = $env:windir+"\System32\drivers\etc\hosts." # gdzie je wpisujemy
 $BackupFile = ($env:windir+"\System32\drivers\etc\hosts_holecert.bak") # backup
 $HoleCertStart = "### Start of "+$HoleCertURL+" content ###" # znacznik początku danych z CERT


### PR DESCRIPTION
The new export endpoint is limited to 6 months of data and should be used instead of the old files.

Reference: https://cert.pl/en/warning-list/
