### PR TITLE
Update URL for downloading certificate report

### DIFF
--- a/DFIR/Get-UnusualRootCerts.ps1
+++ b/DFIR/Get-UnusualRootCerts.ps1
@@ -2,7 +2,7 @@
 # THANK YOU @ASwisstone https://x.com/ASwisstone ! :)
 
 $content = $null
-$content = (Invoke-WebRequest https://ccadb-public.secure.force.com/microsoft/IncludedCACertificateReportForMSFTCSV).Content
+$content = (Invoke-WebRequest https://ccadb.my.salesforce-sites.com/microsoft/IncludedCACertificateReportForMSFTCSV).Content
 
 if (!$content)
 {


### PR DESCRIPTION
Updated URL to new domain according to https://learn.microsoft.com/en-us/security/trusted-root/participants-list making the script work again.